### PR TITLE
Fix vCon specification compliance issues

### DIFF
--- a/src/components/InspectorView.jsx
+++ b/src/components/InspectorView.jsx
@@ -26,14 +26,6 @@ const InspectorView = ({
           <span className="text-gray-400">UUID:</span>
           <span className="font-mono text-sm">{vconData.uuid}</span>
         </div>
-        <div className="flex justify-between">
-          <span className="text-gray-400">Created:</span>
-          <span className="font-mono text-sm">{new Date(vconData.created_at).toLocaleString()}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-gray-400">Subject:</span>
-          <span className="text-sm">{vconData.subject}</span>
-        </div>
       </div>
 
       {/* Tree View */}
@@ -75,20 +67,20 @@ const InspectorView = ({
               <div className="flex items-center gap-2">
                 <span className="text-gray-500">[{i}]</span>
                 <span className="text-xs bg-gray-700 px-2 py-1 rounded">{item.type}</span>
-                <span className="text-xs text-gray-400">{item.mimetype}</span>
+                <span className="text-xs text-gray-400">{item.mediatype}</span>
               </div>
               <div className="text-sm text-gray-400 mt-1">
                 <div>🕐 {new Date(item.start).toLocaleTimeString()} ({item.duration}s)</div>
                 <div><PartyLink parties={item.parties} setSelectedParty={setSelectedParty} /></div>
-                {item.body && typeof item.body === 'string' && item.mimetype === 'text/plain' && (
+                {item.body && typeof item.body === 'string' && item.mediatype === 'text/plain' && (
                   <div className="mt-2 p-2 bg-gray-900 rounded text-xs">
                     {item.body}
                   </div>
                 )}
-                {item.mimetype?.startsWith('audio/') && (
+                {item.mediatype?.startsWith('audio/') && (
                   <div className="mt-2">
                     <audio controls className="w-full h-8">
-                      <source src="#" type={item.mimetype} />
+                      <source src="#" type={item.mediatype} />
                     </audio>
                   </div>
                 )}
@@ -134,7 +126,7 @@ const InspectorView = ({
               <div className="flex items-center gap-2">
                 <span className="text-gray-500">[{i}]</span>
                 <span className="text-xs bg-gray-700 px-2 py-1 rounded">{item.type}</span>
-                <span className="text-xs text-gray-400">{item.mimetype}</span>
+                <span className="text-xs text-gray-400">{item.mediatype}</span>
               </div>
               <div className="text-sm text-gray-400 mt-1">
                 {item.url && (

--- a/src/data/sampleData.js
+++ b/src/data/sampleData.js
@@ -1,9 +1,6 @@
 export const sampleVcon = {
-  "vcon": "1.0.0",
+  "vcon": "0.0.2",
   "uuid": "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14",
-  "created_at": "2024-03-15T10:23:45.123Z",
-  "updated_at": "2024-03-15T10:45:12.456Z",
-  "subject": "Customer Support Call - Order #12345",
   "parties": [
     {
       "tel": "+1-555-123-4567",
@@ -23,7 +20,7 @@ export const sampleVcon = {
       "start": "2024-03-15T10:23:45.123Z",
       "duration": 245.5,
       "parties": [0, 1],
-      "mimetype": "audio/mp3",
+      "mediatype": "audio/mp3",
       "encoding": "base64url",
       "body": "UklGRiQAAABXQVZFZm10..."
     },
@@ -32,7 +29,7 @@ export const sampleVcon = {
       "start": "2024-03-15T10:24:00.000Z",
       "duration": 30.0,
       "parties": [0],
-      "mimetype": "text/plain",
+      "mediatype": "text/plain",
       "body": "Hello, I'm calling about my order that hasn't arrived yet."
     },
     {
@@ -40,7 +37,7 @@ export const sampleVcon = {
       "start": "2024-03-15T10:24:30.000Z",
       "duration": 45.0,
       "parties": [1],
-      "mimetype": "text/plain",
+      "mediatype": "text/plain",
       "body": "I'd be happy to help you with that. Can you please provide your order number?"
     }
   ],
@@ -48,7 +45,7 @@ export const sampleVcon = {
     {
       "type": "transcript",
       "dialog": 0,
-      "mimetype": "application/json",
+      "mediatype": "application/json",
       "body": {
         "vendor": "transcription-service.example",
         "confidence": 0.95,
@@ -58,7 +55,7 @@ export const sampleVcon = {
     {
       "type": "sentiment",
       "dialog": [1, 2],
-      "mimetype": "application/json",
+      "mediatype": "application/json",
       "body": {
         "overall": "neutral",
         "customer_satisfaction": 0.65
@@ -68,7 +65,7 @@ export const sampleVcon = {
   "attachments": [
     {
       "type": "order-details",
-      "mimetype": "application/pdf",
+      "mediatype": "application/pdf",
       "url": "https://example.com/orders/12345.pdf",
       "content_hash": "sha256:abcd1234..."
     }

--- a/src/utils/__tests__/vconValidator.test.js
+++ b/src/utils/__tests__/vconValidator.test.js
@@ -31,8 +31,8 @@ describe('vconValidator', () => {
 
     it('should detect unsigned vCon', () => {
       const unsignedVcon = JSON.stringify({
-        vcon: "0.0.1",
-        uuid: "test-uuid"
+        vcon: "0.0.2",
+        uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14"
       })
       expect(detectVconType(unsignedVcon)).toBe('unsigned')
     })
@@ -59,9 +59,8 @@ describe('vconValidator', () => {
 
     it('should return valid for proper unsigned vCon', () => {
       const validVcon = JSON.stringify({
-        vcon: "0.0.1",
-        uuid: "test-uuid-123",
-        created_at: "2024-01-01T00:00:00Z"
+        vcon: "0.0.2",
+        uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14"
       })
       expect(validateVcon(validVcon)).toBe('valid')
     })
@@ -84,7 +83,7 @@ describe('vconValidator', () => {
 
     it('should return invalid for objects missing required fields', () => {
       const invalidVcon = JSON.stringify({
-        vcon: "0.0.1"
+        vcon: "0.0.2"
         // missing uuid
       })
       expect(validateVcon(invalidVcon)).toBe('invalid')
@@ -101,7 +100,7 @@ describe('vconValidator', () => {
 
   describe('parseVcon', () => {
     it('should parse valid JSON', () => {
-      const testObject = { vcon: "0.0.1", uuid: "test" }
+      const testObject = { vcon: "0.0.2", uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14" }
       const jsonString = JSON.stringify(testObject)
       expect(parseVcon(jsonString)).toEqual(testObject)
     })
@@ -117,8 +116,8 @@ describe('vconValidator', () => {
 
     it('should handle complex nested objects', () => {
       const complexVcon = {
-        vcon: "0.0.1",
-        uuid: "test-uuid",
+        vcon: "0.0.2",
+        uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14",
         parties: [
           { tel: "+1234567890", name: "Party 1" }
         ],

--- a/src/utils/vconValidator.js
+++ b/src/utils/vconValidator.js
@@ -16,24 +16,59 @@ export const detectVconType = (input) => {
   }
 };
 
+const isValidUUID = (uuid) => {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  return uuidRegex.test(uuid);
+};
+
+const validateDialogObject = (dialog) => {
+  if (!dialog.type) return false;
+  const validTypes = ['recording', 'text', 'transfer', 'incomplete'];
+  if (!validTypes.includes(dialog.type)) return false;
+  
+  // Check for required mediatype if body is present
+  if (dialog.body && !dialog.mediatype) return false;
+  
+  return true;
+};
+
 export const validateVcon = (input) => {
   if (!input.trim()) return 'idle';
   
   try {
     const parsed = JSON.parse(input);
     
-    // Basic vCon validation
-    if (parsed.vcon && parsed.uuid) {
-      return 'valid';
-    }
-    
-    // Check for JWS format
+    // Check for JWS format first
     if (parsed.payload && parsed.signatures) {
       return 'valid';
     }
     
     // Check for JWE format
     if (parsed.ciphertext && parsed.protected) {
+      return 'valid';
+    }
+    
+    // Basic vCon validation for unsigned format
+    if (parsed.vcon && parsed.uuid) {
+      // Validate vCon version
+      if (parsed.vcon !== '0.0.2') {
+        return 'invalid';
+      }
+      
+      // Validate UUID format
+      if (!isValidUUID(parsed.uuid)) {
+        return 'invalid';
+      }
+      
+      // Validate dialog objects if present
+      if (parsed.dialog && Array.isArray(parsed.dialog)) {
+        for (const dialog of parsed.dialog) {
+          if (!validateDialogObject(dialog)) {
+            return 'invalid';
+          }
+        }
+      }
+      
       return 'valid';
     }
     


### PR DESCRIPTION
## Summary
- Update vCon version from 1.0.0 to 0.0.2 per current IETF draft specification
- Replace all 'mimetype' fields with 'mediatype' for RFC compliance  
- Remove non-standard fields (created_at, updated_at, subject) from sample data
- Enhance validation with UUID format checking and dialog structure validation
- Update test cases to use spec-compliant values
- Fix UI components to handle removed fields and updated field names

## Test plan
- [x] All existing tests pass (17/17)
- [x] Application builds successfully 
- [x] Sample data validates correctly with enhanced validation
- [x] UI displays properly with updated field names
- [x] No validation errors with spec-compliant vCon objects

These changes ensure full compliance with draft-ietf-vcon-vcon-core-00 and draft-ietf-vcon-vcon-container-03 specifications.

🤖 Generated with [Claude Code](https://claude.ai/code)