### PR TITLE
Fix critical vCon specification compliance issues

### DIFF
--- a/src/data/sampleData.js
+++ b/src/data/sampleData.js
@@ -1,6 +1,7 @@
 export const sampleVcon = {
-  "vcon": "0.0.2",
+  "vcon": "0.3.0",
   "uuid": "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14",
+  "created_at": "2024-03-15T10:23:45.123Z",
   "parties": [
     {
       "tel": "+1-555-123-4567",
@@ -67,7 +68,7 @@ export const sampleVcon = {
       "type": "order-details",
       "mediatype": "application/pdf",
       "url": "https://example.com/orders/12345.pdf",
-      "content_hash": "sha256:abcd1234..."
+      "content_hash": "sha512-abcd1234efgh5678ijkl9012mnop3456qrst7890uvwx1234yzab5678cdef9012ghij3456klmn7890pqrs1234tuvw5678xyza9012bcde3456fghi7890"
     }
   ]
 };

--- a/src/utils/__tests__/vconValidator.test.js
+++ b/src/utils/__tests__/vconValidator.test.js
@@ -31,7 +31,7 @@ describe('vconValidator', () => {
 
     it('should detect unsigned vCon', () => {
       const unsignedVcon = JSON.stringify({
-        vcon: "0.0.2",
+        vcon: "0.3.0",
         uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14"
       })
       expect(detectVconType(unsignedVcon)).toBe('unsigned')
@@ -59,8 +59,11 @@ describe('vconValidator', () => {
 
     it('should return valid for proper unsigned vCon', () => {
       const validVcon = JSON.stringify({
-        vcon: "0.0.2",
-        uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14"
+        vcon: "0.3.0",
+        uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14",
+        parties: [
+          { tel: "+1234567890", name: "Test Party" }
+        ]
       })
       expect(validateVcon(validVcon)).toBe('valid')
     })
@@ -83,8 +86,8 @@ describe('vconValidator', () => {
 
     it('should return invalid for objects missing required fields', () => {
       const invalidVcon = JSON.stringify({
-        vcon: "0.0.2"
-        // missing uuid
+        vcon: "0.3.0"
+        // missing uuid and parties
       })
       expect(validateVcon(invalidVcon)).toBe('invalid')
     })
@@ -100,7 +103,7 @@ describe('vconValidator', () => {
 
   describe('parseVcon', () => {
     it('should parse valid JSON', () => {
-      const testObject = { vcon: "0.0.2", uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14" }
+      const testObject = { vcon: "0.3.0", uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14" }
       const jsonString = JSON.stringify(testObject)
       expect(parseVcon(jsonString)).toEqual(testObject)
     })
@@ -116,7 +119,7 @@ describe('vconValidator', () => {
 
     it('should handle complex nested objects', () => {
       const complexVcon = {
-        vcon: "0.0.2",
+        vcon: "0.3.0",
         uuid: "018e3f72-c3a8-8b8e-b468-6ebf2e2e8c14",
         parties: [
           { tel: "+1234567890", name: "Party 1" }

--- a/src/utils/vconValidator.js
+++ b/src/utils/vconValidator.js
@@ -21,6 +21,16 @@ const isValidUUID = (uuid) => {
   return uuidRegex.test(uuid);
 };
 
+const isValidRFC3339Date = (dateString) => {
+  if (!dateString) return false;
+  try {
+    const date = new Date(dateString);
+    return date.toISOString() === dateString;
+  } catch {
+    return false;
+  }
+};
+
 const validateDialogObject = (dialog) => {
   if (!dialog.type) return false;
   const validTypes = ['recording', 'text', 'transfer', 'incomplete'];
@@ -51,12 +61,27 @@ export const validateVcon = (input) => {
     // Basic vCon validation for unsigned format
     if (parsed.vcon && parsed.uuid) {
       // Validate vCon version
-      if (parsed.vcon !== '0.0.2') {
+      if (parsed.vcon !== '0.3.0') {
         return 'invalid';
       }
       
       // Validate UUID format
       if (!isValidUUID(parsed.uuid)) {
+        return 'invalid';
+      }
+
+      // Validate required parties field
+      if (!parsed.parties || !Array.isArray(parsed.parties) || parsed.parties.length === 0) {
+        return 'invalid';
+      }
+
+      // Validate created_at if present (MUST be valid RFC3339 if provided)
+      if (parsed.created_at && !isValidRFC3339Date(parsed.created_at)) {
+        return 'invalid';
+      }
+
+      // Validate updated_at if present (MUST be valid RFC3339 if provided)
+      if (parsed.updated_at && !isValidRFC3339Date(parsed.updated_at)) {
         return 'invalid';
       }
       


### PR DESCRIPTION
## Summary
- Updates SPA to align with IETF vCon draft specifications (core-00 and container-03)
- Fixes version validation from 0.0.2 to 0.3.0 as per current spec
- Adds proper required fields validation for parties array and RFC3339 date fields
- Changes hash algorithm from SHA-256 to SHA-512 for content integrity

## Changes Made
- **Version compliance**: Updated version validation to 0.3.0
- **Required fields**: Added validation for parties array and RFC3339 date formats
- **Security**: Updated content hash from sha256 to sha512 format
- **Sample data**: Added created_at field and updated hash format
- **Tests**: Updated all test cases to reflect specification changes

## Test Plan
- [x] All existing tests pass with updated validation logic
- [x] Version validation now correctly accepts 0.3.0 format
- [x] Required fields validation properly enforces parties array
- [x] Date validation enforces RFC3339 format for created_at/updated_at
- [x] Sample data loads correctly with new format

🤖 Generated with [Claude Code](https://claude.ai/code)