### PR TITLE
fix: accurate vCon version handling

### DIFF
--- a/docs/processor.js
+++ b/docs/processor.js
@@ -3,8 +3,8 @@
 
 class VConProcessor {
     constructor() {
-        // vCon version support
-        this.supportedVersions = ['0.0.1', '0.3.0', '1.0.0'];
+        // vCon version support aligned with draft-ietf-vcon-vcon-core-00
+        this.supportedVersions = ['0.0.1', '0.0.2', '0.3.0'];
         
         // Required fields as per spec
         this.requiredFields = ['vcon', 'uuid', 'created_at', 'parties'];

--- a/docs/utils.js
+++ b/docs/utils.js
@@ -94,6 +94,23 @@ function isValidGMLPos(gmlpos) {
 }
 
 /**
+ * Compare two semantic version strings
+ * @param {string} a - first version
+ * @param {string} b - second version
+ * @returns {number} 1 if a>b, -1 if a<b, 0 if equal
+ */
+function compareVersions(a, b) {
+    const parse = v => v.split('.').map(num => parseInt(num, 10));
+    const [a1 = 0, a2 = 0, a3 = 0] = parse(a);
+    const [b1 = 0, b2 = 0, b3 = 0] = parse(b);
+
+    if (a1 !== b1) return a1 > b1 ? 1 : -1;
+    if (a2 !== b2) return a2 > b2 ? 1 : -1;
+    if (a3 !== b3) return a3 > b3 ? 1 : -1;
+    return 0;
+}
+
+/**
  * Check if a value has meaningful content (not empty)
  * @param {any} value - Value to check
  * @returns {boolean} True if value has meaningful content
@@ -380,13 +397,14 @@ function setNestedProperty(obj, path, value) {
 }
 
 // Export functions for use by other modules
-window.Utils = {
+const Utils = {
     escapeHtml,
     isValidUUID,
     isValidRFC3339Date,
     isValidTelURL,
     isValidEmail,
     isValidGMLPos,
+    compareVersions,
     hasValidContent,
     formatDate,
     toSafeFilename,
@@ -403,3 +421,11 @@ window.Utils = {
     getNestedProperty,
     setNestedProperty
 };
+
+if (typeof window !== 'undefined') {
+    window.Utils = Utils;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Utils;
+}

--- a/docs/validator.js
+++ b/docs/validator.js
@@ -1,6 +1,13 @@
 // vCon Info - Validator Module
 // Handles vCon validation logic and detailed validation functions
 
+let Utils;
+if (typeof module !== 'undefined' && module.exports) {
+    Utils = require('./utils.js');
+} else if (typeof window !== 'undefined') {
+    Utils = window.Utils;
+}
+
 /**
  * Parse and validate vCon data
  * @param {string} input - Raw vCon input
@@ -455,7 +462,7 @@ function checkVersionSpecificFields(vcon, version) {
         if (!obj || typeof obj !== 'object') return;
         
         // Check for v0.0.1 -> v0.0.2 field changes
-        if (version >= '0.0.2') {
+        if (Utils.compareVersions(version, '0.0.2') >= 0) {
             if (obj.mimetype) {
                 warnings.push(`${path}mimetype deprecated in v0.0.2, use mediatype instead`);
             }
@@ -464,8 +471,8 @@ function checkVersionSpecificFields(vcon, version) {
             }
         }
         
-        // Check for v0.0.2 -> v0.3.0 field changes  
-        if (version >= '0.3.0') {
+        // Check for v0.0.2 -> v0.3.0 field changes
+        if (Utils.compareVersions(version, '0.3.0') >= 0) {
             if (obj['transfer-target']) {
                 warnings.push(`${path}transfer-target deprecated in v0.3.0, use transfer_target instead`);
             }
@@ -475,7 +482,7 @@ function checkVersionSpecificFields(vcon, version) {
         }
         
         // Check for fields that shouldn't exist in older versions
-        if (version < '0.0.2') {
+        if (Utils.compareVersions(version, '0.0.2') < 0) {
             if (obj.mediatype) {
                 warnings.push(`${path}mediatype not available in v${version}, use mimetype instead`);
             }
@@ -484,7 +491,7 @@ function checkVersionSpecificFields(vcon, version) {
             }
         }
         
-        if (version < '0.3.0') {
+        if (Utils.compareVersions(version, '0.3.0') < 0) {
             if (obj.transfer_target) {
                 warnings.push(`${path}transfer_target not available in v${version}, use transfer-target instead`);
             }
@@ -546,7 +553,7 @@ function isValidMediaType(mediaType) {
 }
 
 // Export functions for use by other modules
-window.Validator = {
+const Validator = {
     parseVcon,
     performDetailedValidation,
     validatePartyObject,
@@ -557,3 +564,11 @@ window.Validator = {
     isStandardMediaType,
     isValidMediaType
 };
+
+if (typeof window !== 'undefined') {
+    window.Validator = Validator;
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = Validator;
+}

--- a/tests/unit/version.test.js
+++ b/tests/unit/version.test.js
@@ -1,0 +1,20 @@
+import { describe, test, expect } from "bun:test";
+import { compareVersions } from "../../docs/utils.js";
+import { checkVersionSpecificFields } from "../../docs/validator.js";
+
+describe("Version utilities", () => {
+  test("compareVersions compares numeric components correctly", () => {
+    expect(compareVersions("0.10.0", "0.2.0")).toBe(1);
+    expect(compareVersions("0.3.0", "0.3.0")).toBe(0);
+    expect(compareVersions("0.1.5", "0.1.10")).toBeLessThan(0);
+  });
+
+  test("checkVersionSpecificFields uses numeric comparison", () => {
+    const vcon = { transfer_target: "x" };
+    const resNew = checkVersionSpecificFields(vcon, "0.10.0");
+    expect(resNew.warnings.length).toBe(0);
+
+    const resOld = checkVersionSpecificFields(vcon, "0.2.0");
+    expect(resOld.warnings.some(w => w.includes("transfer_target not available"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- implement semantic version comparison utility
- use numeric comparisons in validator and align supported vCon versions
- add unit tests for version checks

## Testing
- `bun install`
- `bun test` *(fails: Failed to launch the browser process! libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68a0f76cc2fc832fba3e0d6d74917add