### PR TITLE
Fix timeline event formatting

### DIFF
--- a/docs/ui.js
+++ b/docs/ui.js
@@ -741,29 +741,55 @@ function updateExtensionsPanel(extensions) {
 function updateTimeline(timeline) {
     const timelineView = document.getElementById('timeline-view');
     if (!timelineView) return;
-    
+
     if (!timeline || timeline.length === 0) {
         timelineView.innerHTML = '<div class="empty-timeline">No timeline events to display</div>';
         return;
     }
-    
+
+    const formatTime = (time) => {
+        const date = time instanceof Date ? time : new Date(time);
+        if (!isNaN(date.getTime())) {
+            return date.toLocaleString();
+        }
+        if (typeof time === 'object') {
+            try { return JSON.stringify(time); } catch { return 'Unknown time'; }
+        }
+        return String(time || 'Unknown time');
+    };
+
+    const formatText = (text) => {
+        if (text === null || text === undefined) return '';
+        if (typeof text === 'object') {
+            try { return JSON.stringify(text); } catch { return String(text); }
+        }
+        return String(text);
+    };
+
     const html = `
         <div class="timeline-container">
-            ${timeline.map(event => `
-                <div class="timeline-event ${event.type}">
-                    <div class="event-time">${new Date(event.time).toLocaleString()}</div>
-                    <div class="event-description">${escapeHtml(event.description)}</div>
-                    ${event.details ? `
+            ${timeline.map(event => {
+                const timeStr = formatTime(event.time);
+                const description = formatText(event.description);
+                const type = typeof event.type === 'string' ? event.type : 'unknown';
+                const detailsHtml = event.details ? `
                     <div class="event-details">
-                        ${Object.entries(event.details).map(([key, value]) => 
-                            `<span class="detail">${key}: ${escapeHtml(String(value))}</span>`
-                        ).join(', ')}
-                    </div>` : ''}
+                        ${Object.entries(event.details).map(([key, value]) => {
+                            const valStr = formatText(value);
+                            return `<span class="detail">${escapeHtml(key)}: ${escapeHtml(valStr)}</span>`;
+                        }).join(', ')}
+                    </div>` : '';
+                return `
+                <div class="timeline-event ${escapeHtml(type)}">
+                    <div class="event-time">${escapeHtml(timeStr)}</div>
+                    <div class="event-description">${escapeHtml(description)}</div>
+                    ${detailsHtml}
                 </div>
-            `).join('')}
+                `;
+            }).join('')}
         </div>
     `;
-    
+
     timelineView.innerHTML = html;
 }
 

--- a/tests/integration/app-integration.test.js
+++ b/tests/integration/app-integration.test.js
@@ -219,6 +219,39 @@ describe("Integration: App Integration", () => {
     });
   });
 
+  describe("Timeline Display", () => {
+    test("handles invalid values gracefully", async () => {
+      const badVcon = JSON.stringify({
+        vcon: "0.3.0",
+        uuid: "123e4567-e89b-12d3-a456-426614174000",
+        created_at: "2023-12-14T18:59:45.911Z",
+        parties: [{ name: "Alice" }],
+        dialog: [{
+          type: "recording",
+          start: "not-a-date",
+          party_history: [{
+            time: { epoch: 123456 },
+            party: 0,
+            event: { action: "join" }
+          }]
+        }]
+      });
+
+      await page.evaluate(() => {
+        document.getElementById('input-textarea').value = '';
+      });
+      await page.type('#input-textarea', badVcon);
+      await page.waitForTimeout(500);
+
+      await page.click('#tab-timeline');
+      await page.waitForSelector('#timeline-view .timeline-event');
+
+      const timelineText = await page.$eval('#timeline-view', el => el.textContent);
+      expect(timelineText).not.toContain('Invalid Date');
+      expect(timelineText).not.toContain('[object Object]');
+    });
+  });
+
   describe("Inspector Tree", () => {
     test("tree container exists and is accessible", async () => {
       // Ensure we're on inspector tab


### PR DESCRIPTION
## Summary
- prevent timeline from showing `Invalid Date` and `[object Object]`
- add integration test covering invalid timeline data

## Testing
- `bun install`
- `bun test` *(fails: 73 failing tests, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a10134d134832f8a70f0902ca56c2b